### PR TITLE
check once and exit instead of looping

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -122,6 +122,9 @@ while true; do
       fi
     done
   fi
-
-  sleep $interval
+  if [ "$interval" = "0" ]; then    
+     exit 0
+  else
+     sleep $interval
+  fi 
 done


### PR DESCRIPTION
Some users may prefer to schedule git repository checks at set times rather than checking continuously (to reduce hits on remote servers for instance). With this patch, if git-dude's check interval set to 0, the script exits after a single check. Then, using systemd timers in Linux or launchd launch agents in OS X, git-dude runs can be scheduled as desired.